### PR TITLE
Fix dataset slug and clarify auth error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install lerobot durable_rules pyarrow requests phosphobot
 ```bash
 # convert the first episode of a HF dataset into durable_rules
 python demo2rules.py \
-    --dataset Hafnium49/aloha-lite \
+    --dataset Hafnium49/aloha_lite \
     --episode 0 \
     --out rules_autogen.py \
     --left-arm so101_left \

--- a/demo2rules.py
+++ b/demo2rules.py
@@ -32,7 +32,15 @@ def fetch_json(url: str):
     import requests
 
     r = requests.get(url)
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except requests.HTTPError as e:
+        if r.status_code == 401:
+            raise RuntimeError(
+                f"Unauthorized when fetching {url}. "
+                "Check that the dataset slug is correct or that the repo is public."
+            ) from e
+        raise
     return r.json()
 
 


### PR DESCRIPTION
## Summary
- document the correct dataset slug
- raise a clearer message when Hugging Face returns a 401

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e0e6a97f883328a44f17247a5ae03